### PR TITLE
added scaling for bitmapped fonts

### DIFF
--- a/src/ili9342c.c
+++ b/src/ili9342c.c
@@ -823,8 +823,15 @@ STATIC mp_obj_t ili9342c_ILI9342C_text(size_t n_args, const mp_obj_t *args) {
 	else
 		bg_color = _swap_bytes(BLACK);
 
+	mp_int_t scale;
+
+	if (n_args > 7)
+		scale = mp_obj_get_int(args[7]);
+	else
+		scale = 1;
+
 	uint8_t	 wide	  = width / 8;
-	uint16_t buf_size = width * height * 2;
+	uint16_t buf_size = scale * scale * width * height * 2;
 
 	if (self->buffer_size == 0) {
 		self->i2c_buffer = m_malloc(buf_size);
@@ -839,25 +846,29 @@ STATIC mp_obj_t ili9342c_ILI9342C_text(size_t n_args, const mp_obj_t *args) {
 				for (uint8_t line = 0; line < height; line++) {
 					for (uint8_t line_byte = 0; line_byte < wide; line_byte++) {
 						uint8_t chr_data = font_data[chr_idx];
-						for (uint8_t bit = 8; bit; bit--) {
-							if (chr_data >> (bit - 1) & 1)
-								self->i2c_buffer[buf_idx] = fg_color;
-							else
-								self->i2c_buffer[buf_idx] = bg_color;
-							buf_idx++;
+						for (uint8_t sy=0;sy<scale;sy++) {
+							for (uint8_t bit = 8; bit; bit--) {
+								for (uint8_t sx=0;sx<scale;sx++) {
+									if (chr_data >> (bit - 1) & 1)
+										self->i2c_buffer[buf_idx] = fg_color;
+									else
+										self->i2c_buffer[buf_idx] = bg_color;
+									buf_idx++;
+								}
+							}
 						}
 						chr_idx++;
 					}
 				}
-				uint16_t x1 = x0 + width - 1;
+				uint16_t x1 = x0 + width*scale - 1;
 				if (x1 < self->width) {
-					set_window(self, x0, y0, x1, y0 + height - 1);
+					set_window(self, x0, y0, x1, y0 + height*scale - 1);
 					DC_HIGH();
 					CS_LOW();
 					write_spi(self->spi_obj, (uint8_t *) self->i2c_buffer, buf_size);
 					CS_HIGH();
 				}
-				x0 += width;
+				x0 += width*scale;
 			}
 		}
 		if (self->buffer_size == 0) {
@@ -866,7 +877,7 @@ STATIC mp_obj_t ili9342c_ILI9342C_text(size_t n_args, const mp_obj_t *args) {
 	}
 	return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ili9342c_ILI9342C_text_obj, 5, 7, ili9342c_ILI9342C_text);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ili9342c_ILI9342C_text_obj, 5, 8, ili9342c_ILI9342C_text);
 
 STATIC void set_rotation(ili9342c_ILI9342C_obj_t *self) {
 	uint8_t madctl_value = ILI9342C_MADCTL_RGB;


### PR DESCRIPTION
Also this allows scaling up 8x8 fonts like the ones in https://github.com/MiSTer-devel/Fonts_MiSTer

Creating a font from those pf files is as easy as crating a module called my_font.py with the following code:
```
def read_file(file):
    with open(file, mode='rb') as file: 
        return file.read()

WIDTH = 8
HEIGHT = 8
FIRST = 32
LAST = 128
FONT = memoryview(read_file("Arcade_Ghosts_n_Goblins_(Capcom).pf"))
```

