### PR TITLE
Text scaling + support for sparse types

### DIFF
--- a/src/ili9342c.c
+++ b/src/ili9342c.c
@@ -827,8 +827,15 @@ STATIC mp_obj_t ili9342c_ILI9342C_text(size_t n_args, const mp_obj_t *args) {
 	else
 		bg_color = _swap_bytes(BLACK);
 
+	mp_int_t scale;
+
+	if (n_args > 7)
+		scale = mp_obj_get_int(args[7]);
+	else
+		scale = 1;
+
 	uint8_t	 wide	  = width / 8;
-	uint16_t buf_size = width * height * 2;
+	uint16_t buf_size = scale * scale * width * height * 2;
 
 	if (self->buffer_size == 0) {
 		self->i2c_buffer = m_malloc(buf_size);
@@ -843,25 +850,29 @@ STATIC mp_obj_t ili9342c_ILI9342C_text(size_t n_args, const mp_obj_t *args) {
 				for (uint8_t line = 0; line < height; line++) {
 					for (uint8_t line_byte = 0; line_byte < wide; line_byte++) {
 						uint8_t chr_data = font_data[chr_idx];
-						for (uint8_t bit = 8; bit; bit--) {
-							if (chr_data >> (bit - 1) & 1)
-								self->i2c_buffer[buf_idx] = fg_color;
-							else
-								self->i2c_buffer[buf_idx] = bg_color;
-							buf_idx++;
+						for (uint8_t sy=0;sy<scale;sy++) {
+							for (uint8_t bit = 8; bit; bit--) {
+								for (uint8_t sx=0;sx<scale;sx++) {
+									if (chr_data >> (bit - 1) & 1)
+										self->i2c_buffer[buf_idx] = fg_color;
+									else
+										self->i2c_buffer[buf_idx] = bg_color;
+									buf_idx++;
+								}
+							}
 						}
 						chr_idx++;
 					}
 				}
-				uint16_t x1 = x0 + width - 1;
+				uint16_t x1 = x0 + width*scale - 1;
 				if (x1 < self->width) {
-					set_window(self, x0, y0, x1, y0 + height - 1);
+					set_window(self, x0, y0, x1, y0 + height*scale - 1);
 					DC_HIGH();
 					CS_LOW();
 					write_spi(self->spi_obj, (uint8_t *) self->i2c_buffer, buf_size);
 					CS_HIGH();
 				}
-				x0 += width;
+				x0 += width*scale;
 			}
 		}
 		if (self->buffer_size == 0) {
@@ -870,7 +881,7 @@ STATIC mp_obj_t ili9342c_ILI9342C_text(size_t n_args, const mp_obj_t *args) {
 	}
 	return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ili9342c_ILI9342C_text_obj, 5, 7, ili9342c_ILI9342C_text);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ili9342c_ILI9342C_text_obj, 5, 8, ili9342c_ILI9342C_text);
 
 STATIC void set_rotation(ili9342c_ILI9342C_obj_t *self) {
 	uint8_t madctl_value = ILI9342C_MADCTL_RGB;

--- a/src/ili9342c.c
+++ b/src/ili9342c.c
@@ -116,7 +116,11 @@ STATIC void ili9342c_ILI9342C_print(const mp_print_t *print, mp_obj_t self_in, m
 }
 
 STATIC void write_spi(mp_obj_base_t *spi_obj, const uint8_t *buf, int len) {
-	((mp_machine_spi_p_t *) spi_obj->type->protocol)->transfer(spi_obj, len, buf, NULL);
+#if MPY_SPARSE_TYPES
+	((mp_machine_spi_p_t *) MP_OBJ_TYPE_GET_SLOT(spi_obj->type, protocol))->transfer(spi_obj, len, buf, NULL);
+#else
+   	((mp_machine_spi_p_t *) MP_OBJ_TYPE_GET_SLOT(spi_obj->type, protocol))->transfer(spi_obj, len, buf, NULL);
+#endif
 }
 
 STATIC void write_cmd(ili9342c_ILI9342C_obj_t *self, uint8_t cmd, const uint8_t *data, int len) {
@@ -1306,6 +1310,16 @@ STATIC const mp_rom_map_elem_t ili9342c_ILI9342C_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(ili9342c_ILI9342C_locals_dict, ili9342c_ILI9342C_locals_dict_table);
 /* methods end */
 
+#if MPY_SPARSE_TYPES
+MP_DEFINE_CONST_OBJ_TYPE(
+    ili9342c_ILI9342C_type,
+    MP_QSTR_ILI9342C,
+    MP_TYPE_FLAG_NONE,
+	print,	     ili9342c_ILI9342C_print,
+	make_new,    ili9342c_ILI9342C_make_new,
+	locals_dict, (mp_obj_dict_t *) &ili9342c_ILI9342C_locals_dict
+    );
+#else
 const mp_obj_type_t ili9342c_ILI9342C_type = {
 	{&mp_type_type},
 	.name		 = MP_QSTR_ILI9342C,
@@ -1313,6 +1327,7 @@ const mp_obj_type_t ili9342c_ILI9342C_type = {
 	.make_new	 = ili9342c_ILI9342C_make_new,
 	.locals_dict = (mp_obj_dict_t *) &ili9342c_ILI9342C_locals_dict,
 };
+#endif
 
 mp_obj_t ili9342c_ILI9342C_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
 	enum {
@@ -1411,4 +1426,4 @@ const mp_obj_module_t mp_module_ili9342c = {
 	.globals = (mp_obj_dict_t *) &mp_module_ili9342c_globals,
 };
 
-MP_REGISTER_MODULE(MP_QSTR_ili9342c, mp_module_ili9342c, MODULE_ILI9342C_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_ili9342c, mp_module_ili9342c);

--- a/src/mpfile.c
+++ b/src/mpfile.c
@@ -113,9 +113,19 @@ STATIC const mp_rom_map_elem_t mp_file_locals_dict_table[] = {
 };
 STATIC MP_DEFINE_CONST_DICT(mp_file_locals_dict, mp_file_locals_dict_table);
 
+#if MPY_SPARSE_TYPES
+STATIC MP_DEFINE_CONST_OBJ_TYPE(
+    mp_file_type,
+    MP_QSTR_mp_file,
+    MP_TYPE_FLAG_NONE,
+    print, mp_file_print,
+    locals_dict, (mp_obj_dict_t *)&mp_file_locals_dict
+    );
+#else
 STATIC const mp_obj_type_t mp_file_type = {
     .base = { &mp_type_type },
     .name = MP_QSTR_mp_file,
     .print = mp_file_print,
     .locals_dict = (mp_obj_dict_t *)&mp_file_locals_dict,
 };
+#endif

--- a/src/mpfile.h
+++ b/src/mpfile.h
@@ -51,5 +51,10 @@ off_t mp_seek(mp_file_t *file, off_t offset, int whence);
 off_t mp_tell(mp_file_t *file);
 void mp_close(mp_file_t *file);
 
+#if MICROPY_VERSION >= (1<<16 | 19<<8 | 1) // 1.19.1
+#define MPY_SPARSE_TYPES 1
+#else
+#define MPY_SPARSE_TYPES 0
+#endif
 
 #endif // __MICROPY_INCLUDED_PY_MPFILE_H__


### PR DESCRIPTION
Thanks to Flemming Madsen for adding support of sparse types

@russhughes your lib is awesome, please consider merging this PR

Remember that this PR allows scaling up 8x8 fonts like the ones in https://github.com/MiSTer-devel/Fonts_MiSTer

Creating a font from those pf files is as easy as crating a module called my_font.py with the following code:
```python
def read_file(file):
    with open(file, mode='rb') as file: 
        return file.read()

WIDTH = 8
HEIGHT = 8
FIRST = 32
LAST = 128
FONT = memoryview(read_file("Arcade_Ghosts_n_Goblins_(Capcom).pf"))
```